### PR TITLE
fix: add a separator between frontmatter and content

### DIFF
--- a/nodes/Obsidian/shared.ts
+++ b/nodes/Obsidian/shared.ts
@@ -41,7 +41,7 @@ export const writeNote = (
   frontmatter: object,
   content: string,
 ) => {
-  const newFileContent: string = "---\n" + yaml.dump(frontmatter) +
+  const newFileContent: string = "---\n" + yaml.dump(frontmatter) + "---\n" +
     content.trimStart();
 
   writeFileSync(filepath, newFileContent, "utf-8");


### PR DESCRIPTION
Ensure that frontmatter is separated from the contents with `---`